### PR TITLE
Bump NextDNS to 1.7.1

### DIFF
--- a/nextdns/docker/Dockerfile
+++ b/nextdns/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine as builder
-ENV VERSION=1.7.0
+ENV VERSION=1.7.1
 LABEL maintainer="John Dorman <dorman@ataxia.cloud>"
 RUN wget -O /tmp/nextdns.tar.gz https://github.com/nextdns/nextdns/releases/download/v${VERSION}/nextdns_${VERSION}_linux_arm64.tar.gz  \
     && mkdir /tmp/nextdns && tar zxf /tmp/nextdns.tar.gz -C /tmp/nextdns


### PR DESCRIPTION
Couple of fixes relating to local resolution (see commit log, not Github release notes)

https://github.com/nextdns/nextdns/releases/tag/v1.7.1