### PR TITLE
Bump NextDNS client to 1.8.8

### DIFF
--- a/nextdns/docker/Dockerfile
+++ b/nextdns/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine as builder
-ENV VERSION=1.7.1
+ENV VERSION=1.8.8
 LABEL maintainer="John Dorman <dorman@ataxia.cloud>"
 RUN wget -O /tmp/nextdns.tar.gz https://github.com/nextdns/nextdns/releases/download/v${VERSION}/nextdns_${VERSION}_linux_arm64.tar.gz  \
     && mkdir /tmp/nextdns && tar zxf /tmp/nextdns.tar.gz -C /tmp/nextdns


### PR DESCRIPTION
Picks up fixes for some discovery/local resolution.

https://github.com/nextdns/nextdns/releases/tag/v1.8.8

--
Do you still recommend using this now that nextdns has [native support](https://github.com/nextdns/nextdns/wiki/UnifiOS)?