### PR TITLE
Added container-common for #100

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Pull Requests welcome! If you use this functionality to do new cool stuff to you
 
 ### suricata
 Run an updated version of suricata and apply custom rules that survive reboot 
+
 ### on-boot-script
 Do this first. Enables init.d style scripts to run on every boot of your UDM. Includes examples to run wpa-supplicant/eap-proxy and/or ntop-ng on startup. Follow this [readme](https://github.com/boostchicken/udm-utilities/blob/master/on-boot-script/README.md).  
 **It enables complete customization of your UDM/P and fills the gap that config.gateway.json left behind.**
+
+### container-common
+Apply this after on-boot-script. Updates container defaults to maintain **stable disk usage footprint** of custom containers. **Prevents logs filling up UDM storage full**.
 
 ### python
 

--- a/container-common/README.md
+++ b/container-common/README.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-1. **Stable disk usage footprint**: Sets a limit to maximum log size any podman container log can grow up to (from unlimited size to 100Mb). Log file is truncated when a limit is reached.
+1. **Stable disk usage footprint**: Sets a maximum log size any podman container log is allowed to grow up to (from unlimited size to 100Mb). Log "max size" is not a hard limit, but a point when Container Monitor attempts to truncate container log file. **NOTE:** application-specific logs that may be written outside container logs are not truncated by Container Monitor at set limits.
 
 ## Requirements
 

--- a/container-common/README.md
+++ b/container-common/README.md
@@ -1,0 +1,36 @@
+# Container common settings
+
+## Features
+
+1. **Stable disk usage footprint**: Sets a limit to maximum log size any podman container log can grow up to (from unlimited size to 100Mb). Log file is truncated when a limit is reached.
+
+## Requirements
+
+1. You have already setup the on boot script described [here](https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script)
+
+## Customization
+
+While a 100Mb log limit per container should give plenty of log data for all featured in this repo projects, you can increase or decrease max_log_size value in /mnt/data/on_boot.d/05-container-common.sh file after installation.
+
+## Steps
+
+1. Run as root on UDM Pro to download and set permissions of on_boot.d script:
+```sh
+# Download 05-container-common.sh from GitHub
+curl -L https://raw.githubusercontent.com/boostchicken/udm-utilities/master/container-common/on_boot.d/05-container-common.sh -o /mnt/data/on_boot.d/05-container-common.sh;
+# Set execute permission
+chmod a+x /mnt/data/on_boot.d/05-container-common.sh;
+```
+2. Review the script /mnt/data/on_boot.d/05-container-common.sh and when happy execute it.
+```sh
+# Review script
+cat /mnt/data/on_boot.d/05-container-common.sh;
+# Apply container-common settings
+/mnt/data/on_boot.d/05-container-common.sh;
+```
+3. Already running containers will pick up new defaults after either container restart ("podman restart \<container-name\>") or after UDM Pro restart. New containers will pick up a change from first run.
+4. To list containers that are running with log size limits:
+```sh
+# List container monitor processes with "--log-size-max" custom argument set
+ps -ef | grep conmon | grep log-size-max
+```

--- a/container-common/on_boot.d/05-container-common.sh
+++ b/container-common/on_boot.d/05-container-common.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# This script runs before any custom containers start to adjust container common defaults
+
+# Set a limit for container logs. 104857600 Bytes = 100 Megabytes
+sed -i 's/max_log_size = -1/max_log_size = 104857600/g' /etc/containers/libpod.conf;

--- a/homebridge/README.md
+++ b/homebridge/README.md
@@ -7,6 +7,7 @@
 
 ### Requirements
 1. You have successfully setup the on boot script described [here](https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script).
+2. You have applied [container-common](https://github.com/boostchicken/udm-utilities/tree/master/container-common) change to prevent UDM storage to fill up with Homebridge logs and addon error messages that can move fast.
 
 ### Customization
 


### PR DESCRIPTION
Initial release of container-common section that includes setting a limit of container log size any container can have, to prevent filling up UDM storage with excessive logging.