### PR TITLE
Better fix for #71, #86

### DIFF
--- a/on-boot-script/dpkg-build-files/debian/postinst
+++ b/on-boot-script/dpkg-build-files/debian/postinst
@@ -17,13 +17,12 @@ set -e
 # for details, see https://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+alias deb-systemd-invoke='systemctl --no-block --'
 
 case "$1" in
     configure)
        scp -P "$(cat /etc/unifi-os/ssh_proxy_port)" -o StrictHostKeyChecking=no -q /usr/share/udm-boot/on_boot.sh root@localhost:/mnt/data/on_boot.sh
        /sbin/ssh-proxy 'chmod +x /mnt/data/on_boot.sh && mkdir -p /mnt/data/on_boot.d'
-
-       systemctl enable --now udm-boot
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
The fix in #86 certainly works, but it will still produce an error message in journal:

```
Jan 26 15:52:03 ubnt ubnt-dpkg-restore[26]: /usr/sbin/policy-rc.d returned 101, not running 'start udm-boot.service'
```

Here is some technical details about #71.

In `/sbin/ubnt-dpkg-restore`:

``` sh
                disable_service_startup
                restore_packages "${INSTALL_NAMES}"
                cleanup
``` 

Notice the calls to `disable_service_startup` and `cleanup`, here is their implementations in `/sbin/ubnt-dpkg-common`:

``` sh
POLICY_SCRIPT="/usr/sbin/policy-rc.d"

disable_service_startup() {
        mkdir -p $(dirname ${POLICY_SCRIPT})
        cat > ${POLICY_SCRIPT} <<EOF
#!/bin/sh
exit 101
EOF
        chmod 755 "${POLICY_SCRIPT}"
}

cleanup() {
        rm -f "${POLICY_SCRIPT}"
}
```

What ubiquity developers are doing is an ad-hoc hack, that they created a `/usr/sbin/policy-rc.d` which would return 101 on the fly. 101 means `Action not allowed`.

Here is the documentation for invoke-rc.d and policy-rc.d: https://manpages.debian.org/unstable/init-system-helpers/invoke-rc.d.8.en.html

What's happening is that among the code generated by `#DEBHELPER#`, here is the line responsible for starting the service:

``` sh
                deb-systemd-invoke $_dh_action 'udm-boot.service' >/dev/null || true
```

`deb-systemd-invoke` is simply a wrapper script that checks with `invoke-rc.d` before start the service.

The fix for this is deadly simple: just alias deb-systemd-invoke back to systemctl so the wrapper and checker are bypassed.

Now here is one more small improvement in this PR, that it adds `--no-block` option to systemctl, so that if you already have scripts in on_boot.d, they won't slowdown the installation of package (e.g. I have `sleep 10` after wpa_supplicant). The reason behind this is that `/sbin/ubnt-dpkg-restore` actually has a 600 seconds limit on package installation. If somehow on_boot.d contains scripts that in total runs for longer 600 seconds in foreground, the installation be killed. 

Note about `alias`: since shebang is `#!/bin/sh`, `alias` would work in non-interactive shell.
