### PR TITLE
Support caching in install-cni-plugins.sh

### DIFF
--- a/AdguardHome/README.md
+++ b/AdguardHome/README.md
@@ -18,6 +18,8 @@
 
 ## Steps
 
+1. Copy [05-install-cni-plugins.sh](../cni-plugins/05-install-cni-plugins.sh) to /mnt/data/on_boot.d
+1. Execute /mnt/data/on_boot.d/05-install-cni-plugins.sh
 1. On your controller, make a Corporate network with no DHCP server and give it a VLAN. For this example we are using VLAN 5.  You should confirm the bridge is created for this VLAN by running `netstat -r` otherwise the script will fail.  If it is not there, initiate a provisioning of the UDM (Controller > UDM > Config > Manage Device > Force provision).
 1. Copy [10-dns.sh](../dns-common/on_boot.d/10-dns.sh) to `/mnt/data/on_boot.d` and update its values to reflect your environment
 1. Copy [20-dns.conflist](../cni-plugins/20-dns.conflist) to `/mnt/data/podman/cni` after generating a MAC address. This will create your podman macvlan network.

--- a/cni-plugins/05-install-cni-plugins.sh
+++ b/cni-plugins/05-install-cni-plugins.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if test "$#" -eq 0; then
+  set latest
+fi
+
+set "$(basename "$(curl -fsSLo /dev/null -w "%{url_effective}" https://github.com/containernetworking/plugins/releases/$1)")" "$@"
+
+if ! test -f "/mnt/data/.cache/cni-plugins/cni-plugins-linux-arm64-$1.tgz"; then
+  echo "Downloading https://github.com/containernetworking/plugins/releases/download/$1/cni-plugins-linux-arm64-$1.tgz"
+  curl -fsSLo "/tmp/cni-plugins-linux-arm64-$1.tgz" "https://github.com/containernetworking/plugins/releases/download/$1/cni-plugins-linux-arm64-$1.tgz" \
+    && mkdir -p "/mnt/data/.cache/cni-plugins" \
+    && mv "/tmp/cni-plugins-linux-arm64-$1.tgz" "/mnt/data/.cache/cni-plugins/cni-plugins-linux-arm64-$1.tgz"
+fi \
+  && if [ "$1" != "$2" ]; then
+    ln -sf "cni-plugins-linux-arm64-$1.tgz" "/mnt/data/.cache/cni-plugins/cni-plugins-linux-arm64-$2.tgz"
+  fi
+
+test -f "/mnt/data/.cache/cni-plugins/cni-plugins-linux-arm64-$2.tgz" \
+  && echo "Pouring /mnt/data/.cache/cni-plugins/cni-plugins-linux-arm64-$2.tgz" \
+  && rm -rf /opt/cni/bin \
+  && mkdir -p /opt/cni/bin \
+  && tar -xzC /opt/cni/bin -f "/mnt/data/.cache/cni-plugins/cni-plugins-linux-arm64-$2.tgz"

--- a/cni-plugins/install-cni-plugins.sh
+++ b/cni-plugins/install-cni-plugins.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-curl -L https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-arm64-v0.9.0.tgz -o /tmp/cni.tgz
-mkdir -p /mnt/data/podman/cni/
-tar xf /tmp/cni.tgz -C /mnt/data/podman/cni/
-rm /tmp/cni.tgz

--- a/dns-common/on_boot.d/10-dns.sh
+++ b/dns-common/on_boot.d/10-dns.sh
@@ -31,17 +31,13 @@ FORCED_INTFC=""
 # container name; e.g. nextdns, pihole, adguardhome, etc.
 CONTAINER=nextdns
 
-## network configuration and startup:
-CNI_PATH=/mnt/data/podman/cni
-if [ ! -f "$CNI_PATH"/macvlan ]; then
-    mkdir -p $CNI_PATH
-    curl -L https://github.com/containernetworking/plugins/releases/download/v0.9.0/cni-plugins-linux-arm64-v0.9.0.tgz | tar -xz -C $CNI_PATH
+if ! test -f /opt/cni/bin/macvlan; then
+    echo "Error: CNI plugins not found. You can install it with the following command:" >&2
+    echo "       curl -fsSLo /mnt/data/on_boot.d/05-install-cni-plugins.sh https://raw.githubusercontent.com/boostchicken/udm-utilities/master/cni-plugins/05-install-cni-plugins.sh && /bin/sh /mnt/data/on_boot.d/05-install-cni-plugins.sh" >&2
+    exit 1
 fi
 
-mkdir -p /opt/cni
-rm -f /opt/cni/bin
-ln -s $CNI_PATH /opt/cni/bin
-
+CNI_PATH=/mnt/data/podman/cni
 for file in "$CNI_PATH"/*.conflist
 do
     if [ -f "$file" ]; then

--- a/nextdns/README.md
+++ b/nextdns/README.md
@@ -39,6 +39,8 @@ docker buildx build --platform linux/arm64/v8 -t nextdns-udm:latest .
 
 If you have already installed PiHole, skip right to step 5.
 
+1. Copy [05-install-cni-plugins.sh](../cni-plugins/05-install-cni-plugins.sh) to /mnt/data/on_boot.d
+1. Execute /mnt/data/on_boot.d/05-install-cni-plugins.sh
 1. On your controller, make a Corporate network with no DHCP server and give it a VLAN. For this example we are using VLAN 5.
 2. Copy [10-dns.sh](../dns-common/on_boot.d/10-dns.sh) to /mnt/data/on_boot.d and update its values to reflect your environment
 3. Copy [20-dns.conflist](../cni-plugins/20-dns.conflist) to /mnt/data/podman/cni.  This will create your podman macvlan network

--- a/run-pihole/README.md
+++ b/run-pihole/README.md
@@ -17,6 +17,8 @@
 
 ## Steps
 
+1. Copy [05-install-cni-plugins.sh](../cni-plugins/05-install-cni-plugins.sh) to /mnt/data/on_boot.d
+1. Execute /mnt/data/on_boot.d/05-install-cni-plugins.sh
 1. On your controller, make a Corporate network with no DHCP server and give it a VLAN. For this example we are using VLAN 5.
 2. Copy [20-dns.conflist](../cni-plugins/20-dns.conflist) to /mnt/data/podman/cni.  This will create your podman macvlan network
 3. Copy [10-dns.sh](../dns-common/on_boot.d/10-dns.sh) to /mnt/data/on_boot.d and update its values to reflect your environment


### PR DESCRIPTION
Enhance install-cni-plugins.sh to support caching the download and resolve latest version automatically.

This is particularly useful for people use wpa_supplicant as there might be no internet when on_boot.d stuff is loading.

If there is no internet and the download fails, it will attempt to install from disk cache.

Usage:

``` sh
sh install-cni-plugins.sh # install latest version
sh install-cni-plugins.sh v0.9.0 # install a specific version
```
