### PR TITLE
Follow symlinks

### DIFF
--- a/on-boot-script/dpkg-build-files/udm-boot.service
+++ b/on-boot-script/dpkg-build-files/udm-boot.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/sbin/ssh-proxy 'mkdir -p /mnt/data/on_boot.d && find /mnt/data/on_boot.d -mindepth 1 -maxdepth 1 -type f -print0 | sort -z | xargs -0 -r -n 1 -- sh -c '\''if test -x "$0"; then echo "%n: running $0"; "$0"; else case "$0" in *.sh) echo "%n: sourcing $0"; . "$0";; *) echo "%n: ignoring $0";; esac; fi'\'
+ExecStart=/sbin/ssh-proxy 'mkdir -p /mnt/data/on_boot.d && find -L /mnt/data/on_boot.d -mindepth 1 -maxdepth 1 -type f -print0 | sort -z | xargs -0 -r -n 1 -- sh -c '\''if test -x "$0"; then echo "%n: running $0"; "$0"; else case "$0" in *.sh) echo "%n: sourcing $0"; . "$0";; *) echo "%n: ignoring $0";; esac; fi'\'
 RemainAfterExit=true
 
 [Install]


### PR DESCRIPTION
Add parameter to follow symlinks, so that both files and symlinks can be found under on_boot.d

My Setup:
```
# ls -la /mnt/data/on_boot.d/*.sh
lrwxrwxrwx    1 root     root            38 Oct  3  2020 20-alias2dns.sh -> ../vutang50/alias2dns-udm/alias2dns.sh
lrwxrwxrwx    1 root     root            30 Oct  5  2020 99-add_certs.sh -> ../vutang50/certs/add_certs.sh
-rwxr-xr-x    1 root     root            21 Apr  9 00:50 nonsymfile.sh

# podman exec unifi-os systemctl status udm-boot.service
● udm-boot.service - Run On Startup UDM
...
Apr 09 00:53:40 ubnt ssh-proxy[77]: udm-boot.service: running /mnt/data/on_boot.d/20-alias2dns.sh
Apr 09 00:54:05 ubnt ssh-proxy[77]: udm-boot.service: running /mnt/data/on_boot.d/99-add_certs.sh
Apr 09 00:54:05 ubnt ssh-proxy[77]: udm-boot.service: running /mnt/data/on_boot.d/nonsymfile.sh
```