### PR TITLE
Ensure wireguard directory exists before writing keys into it

### DIFF
--- a/wireguard-go/README.md
+++ b/wireguard-go/README.md
@@ -2,14 +2,14 @@
 
 ## Features
 
-1. Wireguard VPN to anywhere! Uses wireguard-go, not the kernel module.
-1. Persists through reboots and firmware updates.
-1. Tested with a Wireguard Server in AWS.
+1. Wireguard VPN to anywhere! Uses wireguard-go, not the kernel module
+1. Persists through reboots and firmware updates
+1. Tested with a Wireguard Server in AWS
 
 ## Requirements
 
 1. You have successfully setup the on boot script described [here](https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script)
-1. Not recommended for Wireguard newbies. Set it up on other devices first. This document does not include iptables / nat rules.
+1. Not recommended for Wireguard newbies. Set it up on other devices first. This document does not include iptables / nat rules
 
 ## Customization
 
@@ -19,24 +19,24 @@
 
 ## Steps
 
-1. Create your public and private keys
+1. Make a directory for your keys and configuration:
+
+    ```sh
+    mkdir -p /mnt/data/wireguard
+    ```
+
+2. Create your public and private keys:
 
     ```sh
     podman run -i --rm --net=host --name wireguard_conf masipcat/wireguard-go wg genkey > /mnt/data/wireguard/privatekey
     podman run -i --rm --net=host --name wireguard_conf masipcat/wireguard-go wg genkey < /mnt/data/wireguard/privatekey > /mnt/data/wireguard/publickey
     ```
 
-2. Make a directory for your configuration
-
-    ```sh
-    mkdir -p /mnt/data/wireguard
-    ```
-
-3. Create a [Wireguard configuration](configs/wg0.conf) in /mnt/data/wireguard.
+3. Create a [Wireguard configuration](configs/wg0.conf) in /mnt/data/wireguard
 4. Copy [20-wireguard.sh](on_boot.d/20-wireguard.sh) to /mnt/data/on_boot.d and update its values to reflect your environment
 5. Execute /mnt/data/on_boot.d/[20-wireguard.sh](on_boot.d/20-wireguard.sh)
 6. If you are running a server, make the appropriate firewall rules / port forwards
-7. Execute the wg command in the container to verify the tunnel is up. It should look something like this.
+7. Execute the wg command in the container to verify the tunnel is up. It should look something like this:
 
     ```sh
     $ podman exec -it wireguard wg


### PR DESCRIPTION
I ran into an error while following the steps, but if we swap the order of the steps such that we create the directory first, it shouldn't be an issue for anyone trying the steps with a fresh install.

I also tried to make the punctuation in the steps more consistent. LMK if you want me to revert the more stylistic edits.