### PR TITLE
add support for multiple keys to be added; plus dropbear conversion

### DIFF
--- a/on-boot-script/examples/udm-files/on_boot.d/15-add-root-ssh-key.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-add-root-ssh-key.sh
@@ -1,10 +1,31 @@
 #!/bin/sh
 
-MY_SSH_KEY="ADD PUBLIC SSH KEY HERE"
+#####################################################
+# ADD RSA KEYS AS BELOW - CHANGE BEFORE RUNNING     #
+#####################################################
+# set -- "ssh-rsa first key here all keys quoted" \ #
+#        "ssh-rsa each line appended with slash " \ #
+# 	 "ssh-rsa last one has no backslash"        #
+#####################################################
+set -- "ssh-rsa AAAABUNCHOFCHARACTERSANDSTUFF me on MyMachine" \
+       "ssh-rsa AAAADIFFERENTKEYWITHCHARSETC! user@myhost"
+
 KEYS_FILE="/root/.ssh/authorized_keys"
 
-# Places public key in ~/.ssh/authorized_keys if not present
-if ! grep -Fxq "$MY_SSH_KEY" "$KEYS_FILE"; then
-    echo "$MY_SSH_KEY" >> "$KEYS_FILE"
-fi
+counter=0
+for key in "$@"
+do
+	## Places public key in ~/.ssh/authorized_keys if not present
+	if ! grep -Fxq "$key" "$KEYS_FILE"; then
+		let counter++
+		echo "$key" >> "$KEYS_FILE"
+	fi
+done
 
+echo $counter keys added to $KEYS_FILE
+
+echo Converting SSH private key to dropbear format 
+#convert ssh key to dropbear for shell interaction
+dropbearconvert openssh dropbear /mnt/data/ssh/id_rsa /root/.ssh/id_rsa
+
+exit 0;

--- a/on-boot-script/examples/udm-files/on_boot.d/15-add-root-ssh-key.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-add-root-ssh-key.sh
@@ -26,6 +26,6 @@ echo $counter keys added to $KEYS_FILE
 
 echo Converting SSH private key to dropbear format 
 #convert ssh key to dropbear for shell interaction
-dropbearconvert openssh dropbear /mnt/data/ssh/id_rsa /root/.ssh/id_rsa
+dropbearconvert openssh dropbear /mnt/data/ssh/id_rsa /root/.ssh/id_dropbear
 
 exit 0;


### PR DESCRIPTION
set it up for multiple keys to be listed; 
also converts root ssh private key to dropbear for using scp on unifi os (scp is dropbear dist)
`scp -i /root/.ssh/id_rsa [source] [dest] `
means scp can be used with no interactive prompts for scripts etc.