### PR TITLE
Fixes required for successful podman replacement

### DIFF
--- a/podman-update/01-podman-update.sh
+++ b/podman-update/01-podman-update.sh
@@ -39,8 +39,8 @@ fi
 ln -s $RUNC_DL /usr/bin/runc
 
 if [ ! -f $SECCOMP ]; then
-  mkdir -p /usr/share/container/
-  curl -fsSLo /usr/share/container/seccomp.json https://github.com/boostchicken/udm-utilities/blob/master/podman-update/bin/seccomp.json?raw=true
+  mkdir -p /usr/share/containers/
+  curl -fsSLo $SECCOMP https://github.com/boostchicken/udm-utilities/blob/master/podman-update/bin/seccomp.json?raw=true
 fi
 sed -i 's/driver = ""/driver = "overlay"/' /etc/containers/storage.conf
 # Comment out if you don't want to enable docker-compose or remote docker admin

--- a/podman-update/01-podman-update.sh
+++ b/podman-update/01-podman-update.sh
@@ -2,13 +2,13 @@
 
 mkdir -p /mnt/data/.cache
 
-PODMAN_VERSION=3.2.0
+PODMAN_VERSION=3.2.0-dev
 RUNC_VERSION=1.0.0-rc95
 CONMON_VERSION=2.0.27
 PODMAN_DL=/mnt/data/.cache/podman-$PODMAN_VERSION
 RUNC_DL=/mnt/data/.cache/runc-$RUNC_VERSION
 CONMON_DL=/mnt/data/.cache/conmon-$CONMON_VERSION
-SECCOMP=/usr/share/container/seccomp.json
+SECCOMP=/usr/share/containers/seccomp.json
 
 while [ ! -f $CONMON_DL ]; do
   curl -fsSLo $CONMON_DL https://github.com/containers/conmon/releases/download/v$CONMON_VERSION/conmon.arm64


### PR DESCRIPTION
Resolves #197

Partially resolves #196 by correctly creating the `/usr/share/containers` folder, and not `/usr/share/container` singular. You may want to rename that folder manually rather than reinstall.

Fixes same typo reported in #188