### PR TITLE
Add some more `on_boot.d` examples

### DIFF
--- a/on-boot-script/examples/udm-files/on_boot.d/15-add-.profile.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-add-.profile.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cp -f /mnt/data/on_boot.d/files/.profile /root/

--- a/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p /mnt/data/.home
+if [ ! -f /mnt/data/.home/.ash_history ]; then
+  cp /root/.ash_history /mnt/data/.home/.ash_history
+fi
+ln -sf /mnt/data/.home/.ash_history /root/.ash_history

--- a/on-boot-script/examples/udm-files/on_boot.d/50-start-node-exporter.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/50-start-node-exporter.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+CONTAINER=node-exporter
+
+# Starts a Prometheus node-exporter container that is deleted after it is stopped.
+if podman container exists "${CONTAINER}"; then
+  podman start "${CONTAINER}"
+else
+  podman run -d --rm --name "${CONTAINER}" --net="host" --pid="host" -v "/:/host:ro,rslave" quay.io/prometheus/node-exporter:latest --path.rootfs=/host
+fi

--- a/on-boot-script/examples/udm-files/on_boot.d/files/.profile
+++ b/on-boot-script/examples/udm-files/on_boot.d/files/.profile
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+alias -='cd -'
+alias ...=../..
+alias ....=../../..
+alias .....=../../../..
+alias ......=../../../../..
+alias cp='cp -i'
+alias la='ls -lAFh'
+alias ll='ls -l'
+alias md='mkdir -p'
+alias mkcd='foo(){ mkdir -p "$1"; cd "$1" }; foo'
+alias mv='mv -i'
+alias rd=rmdir
+alias rm='rm -i'


### PR DESCRIPTION
This PR adds a few more useful examples:

- Adding a `.profile` file to the `root` user home for useful aliases;
- A script to allow preserving shell history from session to session;
- Starting a Prometheus node exporter to allow a remote Grafana instance to keep historical performance data of the UDM Pro.