### PR TITLE
Add logging to DNAT rules

### DIFF
--- a/on-boot-script/examples/udm-files/on_boot.d/15-add-.profile.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-add-.profile.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cp -f /mnt/data/on_boot.d/files/.profile /root/

--- a/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p /mnt/data/.home
+if [ ! -f /mnt/data/.home/.ash_history ]; then
+  cp /root/.ash_history /mnt/data/.home/.ash_history
+fi
+ln -sf /mnt/data/.home/.ash_history /root/.ash_history

--- a/on-boot-script/examples/udm-files/on_boot.d/50-start-node-exporter.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/50-start-node-exporter.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+CONTAINER=node-exporter
+
+# Starts a Prometheus node-exporter container that is deleted after it is stopped.
+if podman container exists "${CONTAINER}"; then
+  podman start "${CONTAINER}"
+else
+  podman run -d --rm --name "${CONTAINER}" --net="host" --pid="host" -v "/:/host:ro,rslave" quay.io/prometheus/node-exporter:latest --path.rootfs=/host
+fi

--- a/on-boot-script/examples/udm-files/on_boot.d/files/.profile
+++ b/on-boot-script/examples/udm-files/on_boot.d/files/.profile
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+alias -='cd -'
+alias ...=../..
+alias ....=../../..
+alias .....=../../../..
+alias ......=../../../../..
+alias cp='cp -i'
+alias la='ls -lAFh'
+alias ll='ls -l'
+alias md='mkdir -p'
+alias mkcd='foo(){ mkdir -p "$1"; cd "$1" }; foo'
+alias mv='mv -i'
+alias rd=rmdir
+alias rm='rm -i'


### PR DESCRIPTION
This PR does the following:

- adds logging to DNAT rules, so that users can see the exact rule being applied in `/var/log/messages`
- mutes errors coming from `iptables -t nat -C`, which can be confusing to users, since they are expected
- improves some shell syntax issues so that the shellcheck linter is happy

Log example:

```
Nov 14 13:06:43 UDM-Pro user.warn kernel: [10132.478629] [DNAT-br0]IN=br0 OUT= MAC=26:5a:4c:a2:b1:02:a0:57:e3:00:78:9e:08:00 SRC=192.168.16.31 DST=212.161.168.15 LEN=71 TOS=0x00 PREC=0x00 TTL=64 ID=3346 DF PROTO=UDP SPT=30958 DPT=53 LEN=51
```