### PR TITLE
ipt-enable-logs

### DIFF
--- a/ipt-enable-logs/README.md
+++ b/ipt-enable-logs/README.md
@@ -1,0 +1,67 @@
+# Enable log tags on your UDM
+
+## Features
+
+If you're used to the Unifi Security Gateway, you may miss the USG log prefixes that allow you to know which rule blocked certain traffic.
+
+This mod adds logging prefixes to messages from `/var/log/messages` allowing you to trace a particular log message to the respective iptable rule (which is generated from the firewall rules you configure on the Network application, among other things)
+
+## Requirements
+
+1. You have successfully setup the on boot script described [here](https://github.com/boostchicken/udm-utilities/tree/master/on-boot-script)
+
+## General idea
+
+This mod builds a small Go program that modifies the existing iptables to add `--log-prefix` to entries that are defined as loggable through the `-j LOG` directive. The Go program is built in a Docker container local to the UDM.
+
+Here's an example snippet of an iptable modified by this program:
+
+```
+-A UBIOS_PREROUTING_USER_HOOK -p tcp -m set --match-set UBIOS_ADDRv4_eth8 dst -m tcp --dport 15060 -j LOG --log-prefix "[DNAT-PRER_U_HK-4294967310] "
+-A UBIOS_PREROUTING_USER_HOOK -p tcp -m set --match-set UBIOS_ADDRv4_eth8 dst -m tcp --dport 15060 -m comment --comment 00000000004294967310 -j DNAT --to-destination 192.168.36.10:15060
+```
+
+## Steps
+
+1. Copy [on_boot.d/30-ipt-enable-logs-launch.sh](./on_boot.d/30-ipt-enable-logs-launch.sh) to /mnt/data/on_boot.d
+1. Copy the [scripts/ipt-enable-logs](./scripts/ipt-enable-logs) folder to /mnt/data/scripts
+1. Copy [scripts/ipt-enable-logs.sh](./scripts/ipt-enable-logs.sh) to /mnt/data/scripts
+1. Execute /mnt/data/on_boot.d/30-ipt-enable-logs-launch.sh
+1. Copy [scripts/refresh-iptables.sh](./scripts/refresh-iptables.sh) to /mnt/data/scripts
+
+## Refreshing iptables
+
+Whenever you update the firewall rules on the Network application, the iptables will be reprovisioned and will need to be reprocessed
+by calling /mnt/data/scripts/refresh-iptables.sh.
+
+## Looking at logs
+
+Logs can be followed easily from another machine through SSH by using the following bash functions:
+
+```shell
+function logunifijson() {
+  ssh unifi "tail -f /var/log/messages" | \
+    rg "kernel:" | \
+    sed "s/]IN/] IN/" | \
+    jq --unbuffered -R '. | rtrimstr(" ") | split(": ") | {date: (.[0] | split(" ") | .[0:3] | join(" "))} + (.[1] | capture("\\[.+\\] \\[(?<rule>.*)\\].*")) + ((.[1] | capture("\\[.+\\] (?<rest>.*)") | .rest | split(" ") | map(select(startswith("[") == false) | split("=") | {(.[0]): .[1]})) | (reduce .[] as $item ({}; . + $item)))'
+}
+
+function logunifi() {
+  logunifijson | jq --unbuffered -r '"\(.date) - \(.rule)\tIN=\(.IN)  \t\(.PROTO)\tSRC=\(.SRC)@\(.SPT)\tDST=\(.DST)@\(.DPT)\tLEN=\(.LEN)\t"'
+}
+```
+
+Here's what the output of `logunifi` looks like:
+
+```
+Nov 14 10:58:31 - A-LAN_LOCAL_U-1097364144127	IN=br0  	TCP	SRC=192.168.16.10@55804	DST=192.168.16.1@443	LEN=52
+Nov 14 10:58:31 - A-LAN_LOCAL_U-1097364144127	IN=br0  	TCP	SRC=192.168.16.10@55804	DST=192.168.16.1@443	LEN=52
+Nov 14 10:58:31 - A-LAN_LOCAL_U-1097364144127	IN=br0  	TCP	SRC=192.168.16.10@55804	DST=192.168.16.1@443	LEN=52
+Nov 14 10:58:31 - A-LAN_LOCAL_U-1097364144127	IN=br0  	TCP	SRC=192.168.16.10@55804	DST=192.168.16.1@443	LEN=52
+Nov 14 10:58:31 - A-LAN_LOCAL_U-1097364144127	IN=br0  	TCP	SRC=192.168.16.10@55804	DST=192.168.16.1@443	LEN=52
+Nov 14 10:58:31 - A-LAN_LOCAL_U-1097364144127	IN=br0  	TCP	SRC=192.168.16.10@55804	DST=192.168.16.1@443	LEN=52
+```
+
+## Acknowledgements
+
+Thanks a lot to [@opustecnica](https://github.com/opustecnica) for the [initial implementation](https://github.com/opustecnica/public/wiki/UDM-&-UDM-PRO-NOTES) and idea (based on a bash script)!

--- a/ipt-enable-logs/on_boot.d/30-ipt-enable-logs-launch.sh
+++ b/ipt-enable-logs/on_boot.d/30-ipt-enable-logs-launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+if ! iptables-save | grep -e '\-A UBIOS_.* \--log-prefix "\[' > /dev/null; then
+  /mnt/data/scripts/ipt-enable-logs.sh | iptables-restore -c
+else
+  echo "iptables already contains USER log prefixes, ignoring."
+fi

--- a/ipt-enable-logs/scripts/ipt-enable-logs.sh
+++ b/ipt-enable-logs/scripts/ipt-enable-logs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+docker run -it --rm -v /mnt/data/scripts/ipt-enable-logs:/src -w /src --network=none golang:1.17.3 go build -v -o /src/ipt-enable-logs /src >&2
+
+/mnt/data/scripts/ipt-enable-logs/ipt-enable-logs

--- a/ipt-enable-logs/scripts/ipt-enable-logs/go.mod
+++ b/ipt-enable-logs/scripts/ipt-enable-logs/go.mod
@@ -1,0 +1,3 @@
+module pedropombeiro.com/ipt-enable-logs
+
+go 1.17

--- a/ipt-enable-logs/scripts/ipt-enable-logs/main.go
+++ b/ipt-enable-logs/scripts/ipt-enable-logs/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	cmd := exec.Command("iptables-save")
+	outputBytes, err := cmd.Output()
+	if err != nil {
+		_ = fmt.Errorf("Failed to run iptables-save: %v", err)
+		os.Exit(1)
+	}
+
+	str := string(outputBytes)
+	lines := strings.Split(str, "\n")
+	re := regexp.MustCompile(`-A UBIOS_([A-Z_]+) .* --comment (\d+) -j ([A-Z]+)`)
+
+	for i, line := range lines {
+		if i != 0 {
+			fmt.Println()
+		}
+		if !strings.HasSuffix(line, "-j LOG") {
+			fmt.Print(line)
+			continue
+		}
+
+		matches := re.FindSubmatch([]byte(lines[i+1]))
+		commentNr, err := strconv.Atoi(string(matches[2]))
+		if err != nil {
+			commentNr = 0
+		}
+		actionName := getActionName(string(matches[3]))
+		ruleName := getRuleName(string(matches[1]), commentNr)
+		fmt.Printf(`%s --log-prefix "[%s-%s] "`, line, actionName, ruleName)
+	}
+}
+
+func getActionName(action string) string {
+	action = strings.Replace(action, "RETURN", "A", 1)
+	action = strings.Replace(action, "REJECT", "R", 1)
+	action = strings.Replace(action, "DROP", "D", 1)
+	action = strings.Replace(action, "MASQUERADE", "M", 1)
+
+	return action
+}
+
+func getRuleName(rule string, commentNr int) string {
+	rule = strings.Replace(rule, "PREROUTING", "PRER", 1)
+	rule = strings.Replace(rule, "POSTROUTING", "POSTR", 1)
+	rule = strings.Replace(rule, "HOOK", "HK", 1)
+	rule = strings.Replace(rule, "USER", "U", 1)
+	if commentNr != 0 {
+		rule = fmt.Sprintf("%s-%d", rule, commentNr)
+	}
+	return rule
+}

--- a/ipt-enable-logs/scripts/refresh-iptables.sh
+++ b/ipt-enable-logs/scripts/refresh-iptables.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+if [ -f /mnt/data/on_boot.d/10-dns.sh ]; then
+  if ! iptables-save | grep -e '\-A PREROUTING.* \--log-prefix "\[' > /dev/null; then
+    /mnt/data/on_boot.d/10-dns.sh
+  else
+    echo "iptables already contains DNAT log prefixes, ignoring."
+  fi
+fi
+
+/mnt/data/on_boot.d/30-ipt-enable-logs-launch.sh

--- a/on-boot-script/examples/udm-files/on_boot.d/15-add-.profile.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-add-.profile.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cp -f /mnt/data/on_boot.d/files/.profile /root/

--- a/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/15-preserve-history.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p /mnt/data/.home
+if [ ! -f /mnt/data/.home/.ash_history ]; then
+  cp /root/.ash_history /mnt/data/.home/.ash_history
+fi
+ln -sf /mnt/data/.home/.ash_history /root/.ash_history

--- a/on-boot-script/examples/udm-files/on_boot.d/50-start-node-exporter.sh
+++ b/on-boot-script/examples/udm-files/on_boot.d/50-start-node-exporter.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+CONTAINER=node-exporter
+
+# Starts a Prometheus node-exporter container that is deleted after it is stopped.
+if podman container exists "${CONTAINER}"; then
+  podman start "${CONTAINER}"
+else
+  podman run -d --rm --name "${CONTAINER}" --net="host" --pid="host" -v "/:/host:ro,rslave" quay.io/prometheus/node-exporter:latest --path.rootfs=/host
+fi

--- a/on-boot-script/examples/udm-files/on_boot.d/files/.profile
+++ b/on-boot-script/examples/udm-files/on_boot.d/files/.profile
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+alias -='cd -'
+alias ...=../..
+alias ....=../../..
+alias .....=../../../..
+alias ......=../../../../..
+alias cp='cp -i'
+alias la='ls -lAFh'
+alias ll='ls -l'
+alias md='mkdir -p'
+alias mkcd='foo(){ mkdir -p "$1"; cd "$1" }; foo'
+alias mv='mv -i'
+alias rd=rmdir
+alias rm='rm -i'


### PR DESCRIPTION
This MR adds the required scripts and instructions to enable firewall rule log prefixes.