### PR TITLE
refactor: dnsmasq config change

### DIFF
--- a/nspawn-container/scripts/10-setup-network.sh
+++ b/nspawn-container/scripts/10-setup-network.sh
@@ -60,8 +60,17 @@ fi
 # Make DNSMasq listen to the container network for split horizon or conditional forwarding
 # Dnsmasq is now started with --conf-dir=/run/dnsmasq.dhcp.conf.d/ so we can drop
 # our own config files into that directory, even if they aren't related to DHCP.
-echo "interface=br${VLAN}.mac" > /run/dnsmasq.dhcp.conf.d/macvlan.conf
-kill -9 "$(cat /run/dnsmasq-main.pid)"
+if [ -d /run/dnsmasq.dhcp.conf.d ]; then
+    # unifi network > 9.3.29
+    echo "interface=br${VLAN}.mac" > /run/dnsmasq.dhcp.conf.d/macvlan.conf
+    kill -9 "$(cat /run/dnsmasq-main.pid)"
+else
+  # older versions
+  if ! grep -qxF "interface=br${VLAN}.mac" /run/dnsmasq.conf.d/custom.conf; then
+    echo "interface=br${VLAN}.mac" >>/run/dnsmasq.conf.d/custom.conf
+    kill -9 "$(cat /run/dnsmasq.pid)"
+  fi
+fi
 
 # (optional) IPv4 force DNS (TCP/UDP 53) through DNS container
 for intfc in ${FORCED_INTFC}; do


### PR DESCRIPTION
After the 9.3.29 UniFi Network update, dnsmasq now handles DHCP as well as DNS, and its config files have been split into separate "dns" and "dhcp" directories. Dnsmasq is launched with `--conf-dir=/run/dnsmasq.dhcp.conf.d/` so any custom settings - even non-DHCP ones - must go into that folder. The old custom.conf no longer works. PID file location also changed.